### PR TITLE
Add Sushi Sprint at PloneConf 2018 in Tokyo

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Where to discover new Pyramid apps and projects.
 
 ## Conferences
 
+* [Sushi Sprint at PloneConf 2018 in Tokyo, Japan](https://2018.ploneconf.org/sprints) (November 10-11, 2018)
 * [Pyramid Workshop in Munich, Germany.](https://pyconweb.com/talks/28-05-2017/pyramid-workshop) (May 28, 2017, 10:30 a.m. - 12:30 p.m.)
 * [PloneConf 2017](https://2017.ploneconf.org/) - Barcelona Plone Digital Experience Conference (16~22 Oct. 2017)
 * [PloneConf 2016](https://2016.ploneconf.org/) - Boston Plone Digital Experience Conference (17~23 Oct. 2016)


### PR DESCRIPTION
Add Sushi Sprint at PloneConf 2018 in Tokyo, Japan on Nov. 10-11 2018